### PR TITLE
Added Network class

### DIFF
--- a/lib/network.rb
+++ b/lib/network.rb
@@ -1,0 +1,27 @@
+require './lib/show'
+
+class Network
+  attr_reader :name,
+              :shows
+
+  def initialize(name)
+    @name = name
+    @shows = []
+  end
+
+  def add_show(show)
+    @shows << show
+  end
+
+  def highest_paid_actor
+    all_actors_of_network.max_by{|actor| actor.salary}.actor
+  end
+
+  def all_actors_of_network
+    all_actors = []
+    @shows.each do |show|
+      all_actors << show.characters
+    end
+    all_actors.flatten
+  end
+end

--- a/test/network_test.rb
+++ b/test/network_test.rb
@@ -1,0 +1,59 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require './lib/network'
+
+class NetworkTest < MiniTest::Test
+
+  def setup
+    @nbc = Network.new("NBC")
+    @kitt = Character.new({name: "KITT",
+                          actor: "William Daniels",
+                          salary: 1_000_000})
+    @michael_knight = Character.new({name: "Michael Knight",
+                                     actor: "David Hasselhoff",
+                                     salary: 1_600_000})
+    @leslie_knope = Character.new({name: "Leslie Knope",
+                                   actor: "Amy Poehler",
+                                   salary: 2_000_000})
+    @ron_swanson = Character.new({name: "Ron Swanson",
+                                  actor: "Nick Offerman",
+                                  salary: 1_400_000})
+
+    @knight_rider = Show.new("Knight Rider",
+                            "Glen Larson",
+                            [@michael_knight,
+                              @kitt])
+    @parks_and_rec = Show.new("Parks and Recreation",
+                              "Michael Shur & Greg Daniels",
+                              [@leslie_knope,
+                                @ron_swanson])
+  end
+
+  def test_it_exists
+    assert_instance_of Network, @nbc
+  end
+
+  def test_it_has_a_name
+    assert_equal "NBC", @nbc.name
+  end
+
+  def test_it_ints_with_empty_shows
+    assert_equal [], @nbc.shows
+  end
+
+  def test_it_has_shows_when_you_add_shows
+    @nbc.add_show(@knight_rider)
+    @nbc.add_show(@parks_and_rec)
+    shows = [@knight_rider,@parks_and_rec]
+
+    assert_equal shows, @nbc.shows
+  end
+
+  def test_it_returns_highest_paid_actors_name_of_all_shows
+    @nbc.add_show(@knight_rider)
+    @nbc.add_show(@parks_and_rec)
+    @nbc.highest_paid_actor
+    
+    assert_equal "Amy Poehler", @nbc.highest_paid_actor
+  end
+end


### PR DESCRIPTION
What does this PR do?
creates a Network class which takes in a single argument of name and sets shows to empty array.
add_show method takes in a single argument of a show instance and adds it to shows.
all_actors_of_network method gathers all actors of shows on Network instance and returns as array.
highest_paid_actor calls all_actors_of_network and finds the actor with the highest salary, returning actors name.